### PR TITLE
Provide a means to wait for the completion of active jobs in a worker

### DIFF
--- a/test/app/test_client.ts
+++ b/test/app/test_client.ts
@@ -19,6 +19,10 @@ describe("celery functional tests", () => {
     worker.start();
   });
 
+  afterEach(() => {
+    return worker.whenCurrentJobsFinished();
+  });
+
   after(() => {
     Promise.all([client.disconnect(), worker.disconnect()]);
 

--- a/test/app/test_worker.ts
+++ b/test/app/test_worker.ts
@@ -17,6 +17,10 @@ describe("node celery worker with redis broker", () => {
     worker.start();
   });
 
+  afterEach(() => {
+    return worker.whenCurrentJobsFinished();
+  });
+
   after(() => {
     worker.disconnect();
     const redis = new Redis();
@@ -80,6 +84,10 @@ describe("node celery worker with amqp broker", () => {
     worker.register("tasks.add_kwargs", ({ a, b }) => a + b);
     worker.register("tasks.add_mixed", (a, b, { c, d }) => a + b + c + d);
     worker.start();
+  });
+
+  afterEach(() => {
+    return worker.whenCurrentJobsFinished();
   });
 
   after(() => {


### PR DESCRIPTION
## Description
This change adds a small amount of infrastructure in the worker and exposes a method to allow waiting for any active jobs it may have in-flight to succeed.

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
feature


* **What is the current behavior?** (You can also link to an open issue here)
The completion of jobs being processed in the worker cannot be awaited.


* **What is the new behavior (if this is a feature change)?**
References to active jobs are kept and a method is exposed to allow waiting for any currently active jobs to complete. The naming of the method is taken from something that performs the same function in `bull`.

* **Other information**:
Perhaps it's worth my providing some context about where the need for this came up - we have a subsequent change in which the message "status" is stored on the AsyncResult object so that we can tell messages apart. As part of that, a test for the timeout behaviour was added. But since the client tests make use of the worker, we have to make sure that all jobs are finish between the test runs so there was a need to wait for their completion. Nevertheless, I think this is a generally useful thing to expose on workers to, for example, allow gracefully shutting them down.