### PR TITLE
Record a response status on the AsyncResult object.

### DIFF
--- a/src/app/result.ts
+++ b/src/app/result.ts
@@ -10,6 +10,7 @@ export class AsyncResult {
   taskId: string;
   backend: CeleryBackend;
   result: any;
+  _promise: Promise<any>;
 
   /**
    * Asynchronous Result
@@ -21,6 +22,7 @@ export class AsyncResult {
     this.taskId = taskId;
     this.backend = backend;
     this.result = null;
+    this._promise = null;
   }
 
   /**
@@ -28,11 +30,11 @@ export class AsyncResult {
    * @returns {Promise}
    */
   get(timeout?: number): Promise<any> {
-    return new Promise((resolve, reject) => {
-      if (this.result) {
-        resolve(this.result);
-      }
+    if (this._promise) {
+      return this._promise;
+    }
 
+    const p = new Promise((resolve, reject) => {
       let timeoutId: NodeJS.Timeout; // eslint-disable-line prefer-const
       let intervalId: NodeJS.Timeout; // eslint-disable-line prefer-const
 
@@ -61,5 +63,7 @@ export class AsyncResult {
         });
       }, 500);
     });
+    this._promise = p;
+    return p;
   }
 }

--- a/src/app/result.ts
+++ b/src/app/result.ts
@@ -1,8 +1,11 @@
 import { CeleryBackend } from "../backends";
 
+type AsyncResultStatus = "PENDING" | "SUCCESS" | "FAILURE" | "TIMEOUT";
+
 export class AsyncResult {
   taskId: string;
   backend: CeleryBackend;
+  status: AsyncResultStatus;
   result: any;
 
   /**
@@ -14,6 +17,7 @@ export class AsyncResult {
   constructor(taskId: string, backend: CeleryBackend) {
     this.taskId = taskId;
     this.backend = backend;
+    this.status = "PENDING";
     this.result = null;
   }
 
@@ -33,6 +37,7 @@ export class AsyncResult {
       if (timeout) {
         timeoutId = setTimeout(() => {
           clearInterval(intervalId);
+          this.status = "TIMEOUT";
           resolve(null);
         }, timeout);
       }
@@ -44,6 +49,8 @@ export class AsyncResult {
               clearTimeout(timeoutId);
             }
             clearInterval(intervalId);
+
+            this.status = msg.status;
             this.result = msg.result;
             resolve(this.result);
           }


### PR DESCRIPTION
## Description
Some services that communicate via celery jobs may not send back a
result. In order to allow distinguishing successful responses from
failures, the message status must be available.

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
feature

* **What is the current behavior?** (You can also link to an open issue here)
The message status can only be inferred (in some cases ambiguously)
from the resolution value of the `.get()` method.

* **What is the new behavior (if this is a feature change)?**
The message status is recorded in the AsyncResult object.

* **Other information**:
As part of this, a job timeout occurring is also exposed via a state
and a test is added for the timeout kicking in.