### PR TITLE
Fix retrieving task result and add feature to get result by taskid

### DIFF
--- a/src/app/client.ts
+++ b/src/app/client.ts
@@ -123,6 +123,15 @@ export default class Client extends Base {
     return new Task(this, name);
   }
 
+  /**
+   * get AsyncResult by task id
+   * @param {string} taskId for task identification.
+   * @returns {AsyncResult} 
+   */
+  public asyncResult(taskId: string): AsyncResult {
+    return new AsyncResult(taskId, this._backend);
+  }
+
   public sendTask(
     taskName: string,
     args?: Array<any>,

--- a/src/app/result.ts
+++ b/src/app/result.ts
@@ -53,11 +53,11 @@ export class AsyncResult {
             }
             clearInterval(intervalId);
 
-            if (msg.status === "SUCCESS") {
+            if (msg.status in ["FAILURE", "REVOKED"]) {
+              reject(createError(msg.status, msg.result));
+            } else {
               this.result = msg.result;
               resolve(this.result);
-            } else {
-              reject(createError(msg.status, msg.result));
             }
           }
         });


### PR DESCRIPTION
## Description
<!-- 
Please describe your pull request.
-->

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Bug fix and feature.


* **What is the current behavior?** (You can also link to an open issue here)

#32 



* **What is the new behavior (if this is a feature change)?**

1. Reject on getting `asyncResult` only if the state is `failure` or `revoked` just as `celery` does.

```python
    'PENDING', 'RECEIVED', 'STARTED', 'SUCCESS', 'FAILURE',
    'REVOKED', 'RETRY', 'IGNORED'
```
There are a lot of result states than just 'SUCCESS' so `get()` should reject only if `failure` or `revoked` 

2. Add asyncResult method on client to get result from backend by just task id
```javascript
const taskIdResult = client.asyncResult("some task id");
taskIdResult.get().then(console.log);
```

* **Other information**:

