### PR TITLE
Getting the result from the backend when status is not ready and add methods result() and status()

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -115,6 +115,21 @@
       "integrity": "sha512-GnZbirvmqZUzMgkFn70c74OQpTTUcCzlhQliTzYjQMqg+hVKcDnxdL19Ne3UdYzdMA/+W3eb646FWn/ZaT1NfQ==",
       "dev": true
     },
+    "@types/sinon": {
+      "version": "9.0.9",
+      "resolved": "https://registry.npmjs.org/@types/sinon/-/sinon-9.0.9.tgz",
+      "integrity": "sha512-z/y8maYOQyYLyqaOB+dYQ6i0pxKLOsfwCmHmn4T7jS/SDHicIslr37oE3Dg8SCqKrKeBy6Lemu7do2yy+unLrw==",
+      "dev": true,
+      "requires": {
+        "@types/sinonjs__fake-timers": "*"
+      }
+    },
+    "@types/sinonjs__fake-timers": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/@types/sinonjs__fake-timers/-/sinonjs__fake-timers-6.0.2.tgz",
+      "integrity": "sha512-dIPoZ3g5gcx9zZEszaxLSVTvMReD3xxyyDnQUjA6IYDG9Ba2AV0otMPs+77sG9ojB4Qr2N2Vk5RnKeuA0X/0bg==",
+      "dev": true
+    },
     "@types/uuid": {
       "version": "3.4.7",
       "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-3.4.7.tgz",

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "@types/chai": "^4.2.9",
     "@types/ioredis": "^4.14.6",
     "@types/mocha": "^7.0.1",
+    "@types/sinon": "^9.0.9",
     "@types/uuid": "^3.4.7",
     "@typescript-eslint/eslint-plugin": "^2.23.0",
     "@typescript-eslint/parser": "^2.23.0",

--- a/src/app/base.ts
+++ b/src/app/base.ts
@@ -7,8 +7,8 @@ import { newCeleryBroker, CeleryBroker } from "../kombu/brokers";
 import { newCeleryBackend, CeleryBackend } from "../backends";
 
 export default class Base {
-  _backend: CeleryBackend;
-  _broker: CeleryBroker;
+  private _backend: CeleryBackend;
+  private _broker: CeleryBroker;
   conf: CeleryConf;
 
   /**

--- a/src/app/client.ts
+++ b/src/app/client.ts
@@ -129,7 +129,7 @@ export default class Client extends Base {
    * @returns {AsyncResult} 
    */
   public asyncResult(taskId: string): AsyncResult {
-    return new AsyncResult(taskId, this._backend);
+    return new AsyncResult(taskId, this.backend);
   }
 
   public sendTask(

--- a/src/app/result.ts
+++ b/src/app/result.ts
@@ -102,7 +102,7 @@ export class AsyncResult {
     return this._cache;
   }
 
-  public get result(): Promise<any> {
+  public result(): Promise<any> {
     return this.getTaskMeta()
       .then((meta) => {
         if (meta) {
@@ -113,7 +113,7 @@ export class AsyncResult {
       });
   }
 
-  public get status(): Promise<string> {
+  public status(): Promise<string> {
     return this.getTaskMeta()
       .then((meta) => {
         if (meta) {

--- a/src/backends/amqp.ts
+++ b/src/backends/amqp.ts
@@ -100,7 +100,7 @@ export default class AMQPBackend implements CeleryBackend {
    * @param {String} taskId
    * @returns {Promise}
    */
-  public getTaskMeta(taskId: string): Promise<any> {
+  public getTaskMeta(taskId: string): Promise<object> {
     const queue = taskId.replace(/-/g, "");
     return this.channel
       .then(ch =>

--- a/src/backends/index.ts
+++ b/src/backends/index.ts
@@ -6,7 +6,7 @@ export interface CeleryBackend {
   isReady: () => Promise<any>;
   disconnect: () => Promise<any>;
   storeResult: (taskId: string, result: any, state: string) => Promise<any>;
-  getTaskMeta: (taskId: string) => Promise<any>;
+  getTaskMeta: (taskId: string) => Promise<object>;
 }
 
 /**

--- a/src/backends/redis.ts
+++ b/src/backends/redis.ts
@@ -114,7 +114,7 @@ export default class RedisBackend implements CeleryBackend {
    * @param {string} taskId
    * @returns {Promise}
    */
-  public getTaskMeta(taskId: string): Promise<any> {
+  public getTaskMeta(taskId: string): Promise<object> {
     return this.get(`${keyPrefix}${taskId}`).then(msg => JSON.parse(msg));
   }
 

--- a/test/app/test_client.ts
+++ b/test/app/test_client.ts
@@ -104,7 +104,7 @@ describe("celery functional tests", () => {
       result
         .get(500)
         .then(() => {
-          done(new Error("should not get here"));
+          assert.fail("should not get here");
         })
         .catch(error => {
           assert.strictEqual(error.message, "TIMEOUT");

--- a/test/app/test_result.ts
+++ b/test/app/test_result.ts
@@ -1,0 +1,186 @@
+import { assert } from "chai";
+import { AsyncResult } from "../../src/app/result";
+import RedisBackend from "../../src/backends/redis";
+import * as sinon from "sinon";
+import * as Redis from "ioredis";
+
+describe("AsyncResult", () => {
+  const redisBackend = new RedisBackend("redis://localhost:6379/0", {});
+
+  let testName: string;
+  beforeEach(function () {
+    testName = this.currentTest.title;
+  });
+  
+  afterEach(() => {
+    sinon.restore();
+  })
+
+  after(() => {
+    redisBackend.disconnect();
+    const redis = new Redis();
+    redis.flushdb().then(() => redis.quit());
+  });
+
+  describe("get", () => {
+    it("should return result when data stored in backend", async () => {
+      // Arrange
+      const testResult = "100";
+      const testStatus = "SUCCESS";
+      const asyncResult = new AsyncResult(testName, redisBackend);
+      await redisBackend.storeResult(testName, testResult, testStatus);
+
+      // Action
+      const result = await asyncResult.get();
+
+      // Assert
+      assert.strictEqual(result, testResult);
+    });
+
+    it("should immediately resolve when the task was previously resolved", done => {
+      // Arrange
+      const testResult = "100";
+      const testStatus = "SUCCESS";
+      const asyncResult = new AsyncResult(testName, redisBackend);
+      const getTaskMetaSpy = sinon.spy(redisBackend, "getTaskMeta");
+      redisBackend.storeResult(testName, testResult, testStatus)
+        .then(() => {
+          // Action
+          asyncResult.get()
+            .then(() => {
+              return asyncResult.get();
+            })
+            .then((result) => {
+              // Assert
+              assert.strictEqual(getTaskMetaSpy.callCount, 1);
+              assert.strictEqual(result, testResult);
+              done();
+            })
+        });
+    });
+
+    it("should throw when status is failure", done => {
+      // Arrange
+      const testResult = "100";
+      const testStatus = "FAILURE";
+      const result = new AsyncResult(testName, redisBackend);
+      redisBackend.storeResult(testName, testResult, testStatus)
+        .then(() => {
+
+          // Action
+          result.get()
+            .then((result) => {
+              assert.fail("should not get here");
+            })
+            .catch(error => {
+              // Assert
+              assert.strictEqual(error.message, "FAILURE");
+              done();
+            });
+        });
+    });
+
+    it("should throw timeout when result is not in backend", done => {
+      // Arrange
+      const result = new AsyncResult(testName, redisBackend);
+      
+      // Action
+      result
+        .get(500)
+        .then(() => {
+          assert.fail("should not get here");
+        })
+        .catch(error => {
+          // Assert
+          assert.strictEqual(error.message, "TIMEOUT");
+          done();
+        });
+    });
+  });
+
+  describe("result", () => {
+    it("should return result when data stored in backend", async () => {
+      // Arrange
+      const testResult = "100";
+      const testStatus = "FAILURE";
+      await redisBackend.storeResult(testName, testResult, testStatus);
+      const asyncResult = new AsyncResult(testName, redisBackend);
+      
+      // Action
+      const result = await asyncResult.result();
+
+      // Assert
+      assert.strictEqual(result, testResult);
+    });
+
+    it("should return null when result is not in backend", async () => {
+      // Arrange
+      const asyncResult = new AsyncResult(testName, redisBackend);
+
+      // Action
+      const result = await asyncResult.result();
+
+      // Assert
+      assert.strictEqual(result, null);
+    });
+  });
+
+  describe("status", () => {
+    it("should return status when data stored in backend", async () => {
+      // Arrange
+      const testResult = "100";
+      const testStatus = "FAILURE";
+      const asyncResult = new AsyncResult(testName, redisBackend);
+      await redisBackend.storeResult(testName, testResult, testStatus);
+
+      // Action
+      const status = await asyncResult.status();
+
+      // Assert
+      assert.strictEqual(status, testStatus);
+    });
+
+    it("should return when result is not in backend", async () => {
+      // Arrange
+      const asyncResult = new AsyncResult(testName, redisBackend);
+
+      // Action
+      const status = await asyncResult.status();
+
+      // Assert
+      assert.strictEqual(status, null);
+    });
+  });
+
+  describe("mixed with get and status", () => {
+    it("should resolve immediately when the task is previously resolved", done => {
+
+      // Arrange
+      const testResult = "100";
+      const testStatus = "SUCCESS";
+      const asyncResult = new AsyncResult(testName, redisBackend);
+      const getTaskMetaSpy = sinon.spy(redisBackend, "getTaskMeta");
+      redisBackend.storeResult(testName, testResult, testStatus)
+        .then(() => {
+
+          // Action
+          asyncResult.get()
+            .then(() => {
+              // await the result a second time
+              return Promise.all([asyncResult.result(), asyncResult.status()]);
+            })
+            .then((result) => {
+
+              // Assert
+              console.log(result);
+              
+              // the backend should not have been invoked more than once
+              assert.strictEqual(getTaskMetaSpy.callCount, 1);
+              assert.strictEqual(result[0], testResult);
+              assert.strictEqual(result[1], testStatus);
+              done();
+            })
+        });
+    });
+  });
+});

--- a/test/backends/test_amqp.ts
+++ b/test/backends/test_amqp.ts
@@ -24,7 +24,7 @@ describe("amqp backend", () => {
 
       backend.storeResult(taskId, 3, "SUCCESS").then(() => {
         backend.getTaskMeta(taskId).then(data => {
-          assert.equal(data.result, 3);
+          assert.equal(data["result"], 3);
           backend.disconnect().then(() => done());
         });
       });

--- a/test/mocha.opts
+++ b/test/mocha.opts
@@ -1,4 +1,4 @@
 -R spec
 --timeout 10000
 test/**/test_*.ts
---compilers ts-node/register
+--require ts-node/register


### PR DESCRIPTION
## Description
<!-- 
Please describe your pull request.
-->

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Feature and bugfix


* **What is the current behavior?** (You can also link to an open issue here)
1. `this._backend` #36 

2. AsyncResult should provide the methods to get status 
There's no way to find the task status now.

3. (Bug) `AsyncResult#get()` resolve the result only once 
even if the status is changed (STARTED -> SUCCESS or FAILURE, STARTED -> PENDING -> SUCCESS or FAILURE)
It should get the result again from the backend.

* **What is the new behavior (if this is a feature change)?**
1. `this.backend` (getter property)

2. See `AsyncResult#result()` and `AsyncResult#status()`

3. `get` resolve only if the cached result status is `SUCCESS or FAILURE or REVOKED`

* **Other information**:
- Added `@types/sinon` for typescript description of sinon.  
- `getTaskMeta` return type changed to object
- Modify mocha.opts to `--require` from `--compilers` which is deprecated.
