### PR TITLE
Add simple Redis backend test which reflects the equivalent AMQP test

### DIFF
--- a/test/backends/test_redis.ts
+++ b/test/backends/test_redis.ts
@@ -1,0 +1,33 @@
+import { assert } from "chai";
+import { v4 } from "uuid";
+import RedisBackend from "../../src/backends/redis";
+
+const redisUrl = "redis://";
+
+describe("redis backend", () => {
+  describe("storeResult", () => {
+    it("just store", done => {
+      const taskId = v4();
+      const backend = new RedisBackend(redisUrl, {});
+
+      backend.storeResult(taskId, 3, "SUCCESS").then(result => {
+        assert.deepEqual(result, [ "OK", 0 ]);
+        backend.disconnect().then(() => done());
+      });
+    });
+  });
+
+  describe("getTaskMeta", () => {
+    it("getTaskMeta with store", done => {
+      const taskId = v4();
+      const backend = new RedisBackend(redisUrl, {});
+
+      backend.storeResult(taskId, 3, "SUCCESS").then(result => {
+        backend.getTaskMeta(taskId).then(data => {
+          assert.equal(data["result"], 3);
+          backend.disconnect().then(() => done());
+        });
+      });
+    });
+  });
+});


### PR DESCRIPTION
## Description

Adds a simple Redis backend test which reflects the current equivalent AMQP test.

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Extra test for the Redis backend. No functionality, no docs, no bug fix.

* **What is the current behavior?** (You can also link to an open issue here)

Only current behaviour is tested.

* **What is the new behavior (if this is a feature change)?**

No additional behaviour has been added.

* **Other information**:

A question I had was whether the two Redis results `[ "OK", 0 ]` from `backend.storeResult()` should leak out of the backend, or instead should be like the AMQP `.storeResult()` and just be `true`? Please let me know your opinion on this and I'd be happy to do a further PR if we want to keep this backend specific enclosed inside the backend. (Note: I haven't yet tried any failures, but I can try that too depending on your thoughts.)
