### PR TITLE
Add default deliveryMode 2 on amqp borker

### DIFF
--- a/src/kombu/brokers/amqp.ts
+++ b/src/kombu/brokers/amqp.ts
@@ -100,6 +100,7 @@ export default class AMQPBroker implements CeleryBroker {
           contentType,
           contentEncoding,
           headers,
+          deliveryMode: 2,
           ...properties
         })
       );


### PR DESCRIPTION
## Description
<!-- 
Please describe your pull request.
-->

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
feature


* **What is the current behavior?** (You can also link to an open issue here)
Messages are transient when using amqp broker, whereas celery messages are persistent.


* **What is the new behavior (if this is a feature change)?**
Default message delivery mode would be persistent.


* **Other information**:
#44 

