### PR TITLE
remove result output in succeded tasks

### DIFF
--- a/src/app/worker.ts
+++ b/src/app/worker.ts
@@ -147,7 +147,7 @@ export default class Worker extends Base {
         const diff = process.hrtime(timeStart);
         console.info(
           `celery.node Task ${taskName}[${taskId}] succeeded in ${diff[0] +
-            diff[1] / 1e9}s: ${result}`
+            diff[1] / 1e9}s.`
         );
         this.backend.storeResult(taskId, result, "SUCCESS");
         this.activeTasks.delete(taskPromise);


### PR DESCRIPTION
## Description
In this pull request I'm suggesting that we remove the result output when a task is succeded. If we need to print the result when a task is finished, we can do a console.info/.log from the task.
Printing the result from the celery.node package, can create issues if we have a huge result output, and when we run this application in a Docker the container logs get flooded with a lot of useless information.

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Removing the result variable from a console.info.

* **What is the current behavior?** (You can also link to an open issue here)
Print all the result into the console of the application;

* **What is the new behavior (if this is a feature change)?**
Print only conclusion information about the task;