### PR TITLE
Add interval parameter in result retrieval

### DIFF
--- a/src/app/result.ts
+++ b/src/app/result.ts
@@ -38,7 +38,7 @@ export class AsyncResult {
    * @method AsyncResult#get
    * @returns {Promise}
    */
-  public get(timeout?: number): Promise<any> {
+  public get(timeout?: number, interval: number = 500): Promise<any> {
     const waitFor = (resolve: (value?: object) => void) => {
       let timeoutId: NodeJS.Timeout; // eslint-disable-line prefer-const
       let intervalId: NodeJS.Timeout; // eslint-disable-line prefer-const
@@ -60,7 +60,7 @@ export class AsyncResult {
             resolve(meta);
           }
         });
-      }, 500);
+      }, interval);
     };
 
     if (!this._cache) {


### PR DESCRIPTION
## Description

Adding `interval` parameter to control polling frequency. Celery uses by default `500ms` which can be a bottleneck depending on the application.

