### PR TITLE
Rethrow when AMQPBroker fails during isReady

### DIFF
--- a/src/kombu/brokers/amqp.ts
+++ b/src/kombu/brokers/amqp.ts
@@ -37,7 +37,7 @@ export default class AMQPBroker implements CeleryBroker {
    * @returns {Promise} promises that continues if amqp connected.
    */
   public isReady(): Promise<amqplib.Channel> {
-    return new Promise(resolve => {
+    return new Promise((resolve, reject) => {
       this.channel.then(ch => {
         Promise.all([
           ch.assertExchange("default", "direct", {
@@ -54,7 +54,9 @@ export default class AMQPBroker implements CeleryBroker {
             // nowait: false,
             arguments: null
           })
-        ]).then(() => resolve());
+        ])
+        .then(() => resolve())
+        .catch(reject);
       });
     });
   }


### PR DESCRIPTION
## Description

When you lost your RabbitMQ connection during an `isReady` call then it triggers an unhandled and uncatchable exception.
This is very inconvenient when you set up a probe to track your application state.

This merge request tends to forward the exception via a reject.

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Feature or bug fix. More a bug fix IMHO.

* **What is the current behaviour?** (You can also link to an open issue here)

Here is the unhandled promise rejection I'm not able to catch:

```
(node:570524) UnhandledPromiseRejectionWarning: IllegalOperationError: Channel closed
    at Channel.<anonymous> (/tmp/debug/node_modules/celery-node/node_modules/amqplib/lib/channel.js:160:11)
    at Channel.C._rpc (/tmp/debug/node_modules/celery-node/node_modules/amqplib/lib/channel.js:142:8)
    at /tmp/debug/node_modules/celery-node/node_modules/amqplib/lib/channel_model.js:59:17
    at tryCatcher (/tmp/debug/node_modules/bluebird/js/release/util.js:16:23)
    at Function.Promise.fromNode.Promise.fromCallback (/tmp/debug/node_modules/bluebird/js/release/promise.js:209:30)
    at Channel.C.rpc (/tmp/debug/node_modules/celery-node/node_modules/amqplib/lib/channel_model.js:58:18)
    at Channel.C.assertExchange (/tmp/debug/node_modules/celery-node/node_modules/amqplib/lib/channel_model.js:124:15)
    at /tmp/debug/node_modules/celery-node/dist/kombu/brokers/amqp.js:31:14
    at tryCatcher (/tmp/debug/node_modules/bluebird/js/release/util.js:16:23)
    at Promise._settlePromiseFromHandler (/tmp/debug/node_modules/bluebird/js/release/promise.js:547:31)
    at Promise._settlePromise (/tmp/debug/node_modules/bluebird/js/release/promise.js:604:18)
    at Promise._settlePromiseCtx (/tmp/debug/node_modules/bluebird/js/release/promise.js:641:10)
    at _drainQueueStep (/tmp/debug/node_modules/bluebird/js/release/async.js:97:12)
    at _drainQueue (/tmp/debug/node_modules/bluebird/js/release/async.js:86:9)
    at Async._drainQueues (/tmp/debug/node_modules/bluebird/js/release/async.js:102:5)
(Use `node --trace-warnings ...` to show where the warning was created)
(node:570524) UnhandledPromiseRejectionWarning: Unhandled promise rejection. This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). To terminate the node process on unhandled promise rejection, use the CLI flag `--unhandled-rejections=strict` (see https://nodejs.org/api/cli.html#cli_unhandled_rejections_mode). (rejection id: 1)
(node:570524) [DEP0018] DeprecationWarning: Unhandled promise rejections are deprecated. In the future, promise rejections that are not handled will terminate the Node.js process with a non-zero exit code.
```

* **What is the new behavior (if this is a feature change)?**

Able to catch the error and deal with it.


