### PR TITLE
Support rediss:// url strings.

### DIFF
--- a/src/app/result.ts
+++ b/src/app/result.ts
@@ -38,7 +38,7 @@ export class AsyncResult {
    * @method AsyncResult#get
    * @returns {Promise}
    */
-  public get(timeout?: number, interval: number = 500): Promise<any> {
+  public get(timeout?: number, interval = 500): Promise<any> {
     const waitFor = (resolve: (value?: object) => void) => {
       let timeoutId: NodeJS.Timeout; // eslint-disable-line prefer-const
       let intervalId: NodeJS.Timeout; // eslint-disable-line prefer-const

--- a/src/backends/index.ts
+++ b/src/backends/index.ts
@@ -14,7 +14,7 @@ export interface CeleryBackend {
  * @private
  * @constant
  */
-const supportedProtocols = ["redis", "amqp", "amqps"];
+const supportedProtocols = ["redis", "rediss", "amqp", "amqps"];
 
 /**
  * takes url string and after parsing scheme of url, returns protocol.
@@ -43,7 +43,7 @@ export function newCeleryBackend(
   CELERY_BACKEND_OPTIONS: object
 ): CeleryBackend {
   const brokerProtocol = getProtocol(CELERY_BACKEND);
-  if (brokerProtocol === "redis") {
+  if (['redis', 'rediss'].indexOf(brokerProtocol) > -1) {
     return new RedisBackend(CELERY_BACKEND, CELERY_BACKEND_OPTIONS);
   }
 

--- a/src/backends/redis.ts
+++ b/src/backends/redis.ts
@@ -45,10 +45,14 @@ export default class RedisBackend implements CeleryBackend {
    * @param {object} opts the options object for redis connect of ioredis
    */
   constructor(url: string, opts: object) {
-    this.redis = new Redis({
-      ...redisOptsFromUrl(url),
-      ...opts
-    });
+    if (url.startsWith("rediss://")){
+      this.redis = new Redis(url, {...opts});
+    } else {
+      this.redis = new Redis({
+        ...redisOptsFromUrl(url),
+        ...opts
+      });
+    }
   }
 
   /**

--- a/src/kombu/brokers/index.ts
+++ b/src/kombu/brokers/index.ts
@@ -20,7 +20,7 @@ export interface CeleryBroker {
  * @private
  * @constant
  */
-const supportedProtocols = ["redis", "amqp", "amqps"];
+const supportedProtocols = ["redis", "rediss", "amqp", "amqps"];
 
 /**
  * takes url string and after parsing scheme of url, returns protocol.
@@ -51,7 +51,7 @@ export function newCeleryBroker(
   CELERY_QUEUE = "celery"
 ): CeleryBroker {
   const brokerProtocol = getProtocol(CELERY_BROKER);
-  if (brokerProtocol === "redis") {
+  if (['redis', 'rediss'].indexOf(brokerProtocol) > -1) {
     return new RedisBroker(CELERY_BROKER, CELERY_BROKER_OPTIONS);
   }
 

--- a/src/kombu/brokers/redis.ts
+++ b/src/kombu/brokers/redis.ts
@@ -53,10 +53,14 @@ export default class RedisBroker implements CeleryBroker {
    * @param {object} opts the options object for redis connect of ioredis
    */
   constructor(url: string, opts: object) {
-    this.redis = new Redis({
-      ...redisOptsFromUrl(url),
-      ...opts
-    });
+    if (url.startsWith("rediss://")){
+      this.redis = new Redis(url, {...opts});
+    } else {
+      this.redis = new Redis({
+        ...redisOptsFromUrl(url),
+        ...opts
+      });
+    }
   }
 
   /**


### PR DESCRIPTION
## Description
Tackles [https://github.com/actumn/celery.node/issues/79](https://github.com/actumn/celery.node/issues/79) and adds support for `rediss://` url strings for brokers and backends.

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

enhancement

* **What is the current behavior?** (You can also link to an open issue here)

[https://github.com/actumn/celery.node/issues/79](https://github.com/actumn/celery.node/issues/79)
`rediss://` protocol is not permitted for backends or brokers.

* **What is the new behavior (if this is a feature change)?**

A celery.node client/worker can start with `rediss://`

* **Other information**:

This has been tested against an AWS Elasticache Redis instance which required TLS. (Using modified urls in the example redis tutorial).

Eg: `client = celery.createClient("rediss://:<pwd>@<elasticache-endpoint>:6379/0", "rediss://:<pwd>@<elasticache-endpoint>:6379/0")`
