### PR TITLE
Support partial manual routing

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "celery-node",
-  "version": "0.5.9",
+  "version": "0.5.10",
   "description": "celery written in nodejs",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/app/client.ts
+++ b/src/app/client.ts
@@ -121,8 +121,8 @@ export default class Client extends Base {
    * @example
    * client.createTask('task.add').delay([1, 2])
    */
-  public createTask(name: string): Task {
-    return new Task(this, name);
+  public createTask(name: string, options?: TaskOptions): Task {
+    return new Task(this, name, options);
   }
 
   /**

--- a/src/app/client.ts
+++ b/src/app/client.ts
@@ -1,6 +1,7 @@
 import { v4 } from "uuid";
 import Base from "./base";
 import Task from "./task";
+import type { TaskOptions } from "./task";
 import { AsyncResult } from "./result";
 
 class TaskMessage {
@@ -12,6 +13,7 @@ class TaskMessage {
   ) {}
 }
 
+
 export default class Client extends Base {
   private taskProtocols = {
     1: this.asTaskV1,
@@ -22,7 +24,7 @@ export default class Client extends Base {
     return this.taskProtocols[this.conf.TASK_PROTOCOL];
   }
 
-  public sendTaskMessage(taskName: string, message: TaskMessage): void {
+  public sendTaskMessage(taskName: string, message: TaskMessage, options: TaskOptions = {}): void {
     const { headers, properties, body /*, sentEvent */ } = message;
 
     const exchange = "";
@@ -32,8 +34,8 @@ export default class Client extends Base {
     this.isReady().then(() =>
       this.broker.publish(
         body,
-        exchange,
-        this.conf.CELERY_QUEUE,
+        options?.exchange ?? exchange,
+        options?.routingKey ?? this.conf.CELERY_QUEUE,
         headers,
         properties
       )
@@ -136,11 +138,12 @@ export default class Client extends Base {
     taskName: string,
     args?: Array<any>,
     kwargs?: object,
-    taskId?: string
+    taskId?: string,
+    options?: TaskOptions
   ): AsyncResult {
     taskId = taskId || v4();
     const message = this.createTaskMessage(taskId, taskName, args, kwargs);
-    this.sendTaskMessage(taskName, message);
+    this.sendTaskMessage(taskName, message, options);
 
     const result = new AsyncResult(taskId, this.backend);
     return result;

--- a/src/app/task.ts
+++ b/src/app/task.ts
@@ -1,19 +1,37 @@
 import Client from "./client";
 import { AsyncResult } from "./result";
 
+/** Task executation options
+ * Originally allows these keys:
+ *  ['queue', 'routing_key', 'exchange', 'priority', 'expires',
+ *   'serializer', 'delivery_mode', 'compression', 'time_limit',
+ *   'soft_time_limit', 'immediate', 'mandatory']
+ * but now only part of them are supported.
+*/
+export type TaskOptions = {
+  exchange?: string;
+  queue?: string;
+  routingKey?: string;
+}
+
 export default class Task {
   client: Client;
   name: string;
+  options?: TaskOptions;
 
   /**
    * Asynchronous Task
    * @constructor Task
    * @param {Client} clinet celery client instance
    * @param {string} name celery task name
+   * @param {Object} [options]
+   * @param {string} [options.queue] queue name
+   * @param {string} [options.routingKey] routing key
    */
-  constructor(client: Client, name: string) {
+  constructor(client: Client, name: string, options: TaskOptions = {}) {
     this.client = client;
     this.name = name;
+    this.options = options;
   }
 
   /**
@@ -28,7 +46,7 @@ export default class Task {
     return this.applyAsync([...args]);
   }
 
-  public applyAsync(args: Array<any>, kwargs?: object): AsyncResult {
+  public applyAsync(args: Array<any>, kwargs?: object, options?: TaskOptions): AsyncResult {
     if (args && !Array.isArray(args)) {
       throw new Error("args is not array");
     }
@@ -37,6 +55,6 @@ export default class Task {
       throw new Error("kwargs is not object");
     }
 
-    return this.client.sendTask(this.name, args || [], kwargs || {});
+    return this.client.sendTask(this.name, args || [], kwargs || {}, undefined, options || this.options);
   }
 }


### PR DESCRIPTION
## Description

Partially solved the problem that the `queue` name and `routingKey` determined at the time of client creation cannot be changed.

Due to the design of the current code, `queue` and `routingKey` are treated as same. Therefore, I only added an option to change the `routingKey` when creating a task or when sending a task message.

```ts
const task = client.createTask("tasks.multiply", { routingKey: "my_queue" });
const result = task. applyAsync([2, 3]);
```
or
```ts
const task = client. createTask("tasks. multiply");
const result = task.applyAsync([2, 3], undefined, { routingKey: "my_queue" });
```

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

  Enhancement

* **What is the current behavior?** (You can also link to an open issue here)

  The `queue` name and `routingKey` determined at the time of client creation cannot be changed after creation.
  Related: #94

* **What is the new behavior (if this is a feature change)?**

  Each tasks can have their own `routingKey`

