### PR TITLE
Adding chain support on V2 protocol

### DIFF
--- a/src/app/client.ts
+++ b/src/app/client.ts
@@ -1,14 +1,14 @@
-import {v4} from "uuid";
+import { v4 } from "uuid";
 import Base from "./base";
 import Task from "./task";
-import {AsyncResult} from "./result";
+import { AsyncResult } from "./result";
 
 export class TaskMessage {
   constructor(
-      readonly headers: object,
-      readonly properties: object,
-      readonly body: [Array<any>, object, object] | object,
-      readonly sentEvent: object
+    readonly headers: object,
+    readonly properties: object,
+    readonly body: [Array<any>, object, object] | object,
+    readonly sentEvent: object
   ) {}
 }
 
@@ -30,21 +30,21 @@ export default class Client extends Base {
     // const serializer = 'json';
 
     this.isReady().then(() =>
-        this.broker.publish(
-            body,
-            exchange,
-            this.conf.CELERY_QUEUE,
-            headers,
-            properties
-        )
+      this.broker.publish(
+        body,
+        exchange,
+        this.conf.CELERY_QUEUE,
+        headers,
+        properties
+      )
     );
   }
 
   public asTaskV2(
-      taskId: string,
-      taskName: string,
-      args?: Array<any>,
-      kwargs?: object
+    taskId: string,
+    taskName: string,
+    args?: Array<any>,
+    kwargs?: object
   ): TaskMessage {
     const message: TaskMessage = {
       headers: {
@@ -87,10 +87,10 @@ export default class Client extends Base {
    * @returns {String} JSON serialized string of celery task message
    */
   public asTaskV1(
-      taskId: string,
-      taskName: string,
-      args?: Array<any>,
-      kwargs?: object
+    taskId: string,
+    taskName: string,
+    args?: Array<any>,
+    kwargs?: object
   ): TaskMessage {
     const message: TaskMessage = {
       headers: {},
@@ -133,10 +133,10 @@ export default class Client extends Base {
   }
 
   public sendTask(
-      taskName: string,
-      args?: Array<any>,
-      kwargs?: object,
-      taskId?: string
+    taskName: string,
+    args?: Array<any>,
+    kwargs?: object,
+    taskId?: string
   ): AsyncResult {
     taskId = taskId || v4();
     const message = this.createTaskMessage(taskId, taskName, args, kwargs);

--- a/src/app/client.ts
+++ b/src/app/client.ts
@@ -1,7 +1,7 @@
-import { v4 } from "uuid";
+import {v4} from "uuid";
 import Base from "./base";
 import Task from "./task";
-import { AsyncResult } from "./result";
+import {AsyncResult} from "./result";
 
 export class TaskMessage {
   constructor(

--- a/src/app/client.ts
+++ b/src/app/client.ts
@@ -3,12 +3,12 @@ import Base from "./base";
 import Task from "./task";
 import { AsyncResult } from "./result";
 
-class TaskMessage {
+export class TaskMessage {
   constructor(
-    readonly headers: object,
-    readonly properties: object,
-    readonly body: [Array<any>, object, object] | object,
-    readonly sentEvent: object
+      readonly headers: object,
+      readonly properties: object,
+      readonly body: [Array<any>, object, object] | object,
+      readonly sentEvent: object
   ) {}
 }
 
@@ -30,21 +30,21 @@ export default class Client extends Base {
     // const serializer = 'json';
 
     this.isReady().then(() =>
-      this.broker.publish(
-        body,
-        exchange,
-        this.conf.CELERY_QUEUE,
-        headers,
-        properties
-      )
+        this.broker.publish(
+            body,
+            exchange,
+            this.conf.CELERY_QUEUE,
+            headers,
+            properties
+        )
     );
   }
 
   public asTaskV2(
-    taskId: string,
-    taskName: string,
-    args?: Array<any>,
-    kwargs?: object
+      taskId: string,
+      taskName: string,
+      args?: Array<any>,
+      kwargs?: object
   ): TaskMessage {
     const message: TaskMessage = {
       headers: {
@@ -87,10 +87,10 @@ export default class Client extends Base {
    * @returns {String} JSON serialized string of celery task message
    */
   public asTaskV1(
-    taskId: string,
-    taskName: string,
-    args?: Array<any>,
-    kwargs?: object
+      taskId: string,
+      taskName: string,
+      args?: Array<any>,
+      kwargs?: object
   ): TaskMessage {
     const message: TaskMessage = {
       headers: {},
@@ -126,17 +126,17 @@ export default class Client extends Base {
   /**
    * get AsyncResult by task id
    * @param {string} taskId for task identification.
-   * @returns {AsyncResult} 
+   * @returns {AsyncResult}
    */
   public asyncResult(taskId: string): AsyncResult {
     return new AsyncResult(taskId, this.backend);
   }
 
   public sendTask(
-    taskName: string,
-    args?: Array<any>,
-    kwargs?: object,
-    taskId?: string
+      taskName: string,
+      args?: Array<any>,
+      kwargs?: object,
+      taskId?: string
   ): AsyncResult {
     taskId = taskId || v4();
     const message = this.createTaskMessage(taskId, taskName, args, kwargs);

--- a/src/app/worker.ts
+++ b/src/app/worker.ts
@@ -1,7 +1,7 @@
 import Base from "./base";
-import {Message} from "../kombu/message";
-import {createClient} from "../index";
-import Client, {TaskMessage} from "./client";
+import { Message } from "../kombu/message";
+import { createClient } from "../index";
+import Client, { TaskMessage } from "./client";
 
 export default class Worker extends Base {
   handlers: object = {};
@@ -130,7 +130,7 @@ export default class Worker extends Base {
       }
 
       // request
-      const [args, kwargs , embed ] = body;
+      const [args, kwargs, embed] = body;
       const taskId = headers["id"];
 
       const handler = this.handlers[taskName];
@@ -139,29 +139,33 @@ export default class Worker extends Base {
       }
 
       console.info(
-          `celery.node Received task: ${taskName}[${taskId}], args: ${args}, kwargs: ${JSON.stringify(
-              kwargs
-          )}`
+        `celery.node Received task: ${taskName}[${taskId}], args: ${args}, kwargs: ${JSON.stringify(
+          kwargs
+        )}`
       );
 
       const timeStart = process.hrtime();
-      const chain = embed.chain
-      const taskPromise = handler(...args, kwargs).then(result => {
-        const diff = process.hrtime(timeStart);
-        if (chain !== null){
-          this.sendChainTask(chain, message)
-        }
-        console.info(
+      const chain = embed.chain;
+      const taskPromise = handler(...args, kwargs)
+        .then(result => {
+          const diff = process.hrtime(timeStart);
+          if (chain !== null) {
+            this.sendChainTask(chain, message);
+          }
+          console.info(
             `celery.node Task ${taskName}[${taskId}] succeeded in ${diff[0] +
-            diff[1] / 1e9}s: ${result}`
-        );
-        this.backend.storeResult(taskId, result, "SUCCESS");
-        this.activeTasks.delete(taskPromise);
-      }).catch(err => {
-        console.info(`celery.node Task ${taskName}[${taskId}] failed: [${err}]`);
-        this.backend.storeResult(taskId, err, "FAILURE");
-        this.activeTasks.delete(taskPromise);
-      });
+              diff[1] / 1e9}s: ${result}`
+          );
+          this.backend.storeResult(taskId, result, "SUCCESS");
+          this.activeTasks.delete(taskPromise);
+        })
+        .catch(err => {
+          console.info(
+            `celery.node Task ${taskName}[${taskId}] failed: [${err}]`
+          );
+          this.backend.storeResult(taskId, err, "FAILURE");
+          this.activeTasks.delete(taskPromise);
+        });
 
       // record the executing task
       this.activeTasks.add(taskPromise);
@@ -192,26 +196,26 @@ export default class Worker extends Base {
   }
 
   private sendChainTask(chain: Array<any>, requestMessage: Message): void {
-    const chainToSend : any[] = chain
-    const children = chainToSend.pop()
-    const client : Client = createClient(
-        this.conf.CELERY_BROKER,
-        this.conf.CELERY_BACKEND,
-        children.options.queue
-    )
-    const message : TaskMessage = {
+    const chainToSend: any[] = chain;
+    const children = chainToSend.pop();
+    const client: Client = createClient(
+      this.conf.CELERY_BROKER,
+      this.conf.CELERY_BACKEND,
+      children.options.queue
+    );
+    const message: TaskMessage = {
       headers: {
         lang: "js",
         task: children.task,
         id: children.options.task_id,
-        root_id: requestMessage.headers['root_id'],
-        parent_id: requestMessage.headers['id']
+        root_id: requestMessage.headers["root_id"],
+        parent_id: requestMessage.headers["id"]
       },
       properties: {
         correlation_id: children.options.task_id,
-        reply_to: requestMessage.properties['reply_to'],
+        reply_to: requestMessage.properties["reply_to"],
         delivery_mode: 2,
-        priority: 0,
+        priority: 0
       },
       body: [
         children.args,
@@ -223,8 +227,8 @@ export default class Worker extends Base {
           chord: null
         }
       ],
-      sentEvent:null
+      sentEvent: null
     };
-    client.sendTaskMessage(children.task, message)
+    client.sendTaskMessage(children.task, message);
   }
 }

--- a/src/app/worker.ts
+++ b/src/app/worker.ts
@@ -1,6 +1,5 @@
 import Base from "./base";
-import { Message } from "../kombu/message";
-import {newCeleryBroker} from "../kombu/brokers";
+import {Message} from "../kombu/message";
 import {createClient} from "../index";
 import Client, {TaskMessage} from "./client";
 

--- a/src/app/worker.ts
+++ b/src/app/worker.ts
@@ -195,6 +195,12 @@ export default class Worker extends Base {
     throw new Error("not implemented yet");
   }
 
+  /**
+   * @method Worker#sendChainTask
+   * @param chain the chain sent by the local/remote client
+   * @param requestMessage the message sent by the local/remote client
+   * @private
+   */
   private sendChainTask(chain: Array<any>, requestMessage: Message): void {
     const chainToSend: any[] = chain;
     const children = chainToSend.pop();


### PR DESCRIPTION
## Description
<!-- 
The goal is to adding chain support on V2 protocol ( cf: [chain documentation](https://docs.celeryq.dev/en/stable/userguide/canvas.html#chains) )
-->

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
feature


* **What is the current behavior?** (You can also link to an open issue here)
Actually, celery-node considers that the chain returned in embed.chain is always `null`


* **What is the new behavior (if this is a feature change)?**

The goal was to implement the chain process in the celery-node library to fit our need for celery.chain with remote tasks (tasks that are not on the same server as the client, here Django). We were inspired by the Python code ([celery/app/trace.trace_task](https://github.com/celery/celery/blob/main/celery/app/trace.py#L386)) to implement the Worker.createTaskHandler function.

When launching the task, if it succeeds, we check if the received message has a chain. If it does, we call the sendChainTask method.

In the method, we extract the last item from the chain (the next task to be executed) and store it in a variable children. Then, we create a client (which will publish the task to the broker), using the queue defined in children. We create the message according to the Celery protocol V2. Finally, we push the message to the broker with client.sendTaskMessage.


* **Other information**:


